### PR TITLE
Solver options

### DIFF
--- a/src/DiscreteValueIteration.jl
+++ b/src/DiscreteValueIteration.jl
@@ -11,7 +11,6 @@ import POMDPs: Solver, solve, Policy, action, value
 export
     ValueIterationPolicy,
     ValueIterationSolver,
-    create_policy,
     solve,
     action,
     value,

--- a/src/docs.jl
+++ b/src/docs.jl
@@ -3,6 +3,9 @@ The solver type. Contains two parameters that are keyworded in the constructor:
 
     - max_iterations::Int64, the maximum number of iterations value iteration runs for (default 100)
     - belres::Float64, the Bellman residual (default 1e-3)
+    - verbose::Bool, if set to true, the bellman residual and the time per iteration will be printed to STDOUT (default false)
+    - include_Q::Bool, if set to true, the solver outputs the Q values in addition to the utility and the policy (default true)
+    - init_util::Vector{Float64}, provides a custom initialization of the utility vector. (initializes utility to 0 by default)
 
 The solver can be initialized by running:
     `solver = ValueIterationSolver(max_iterations=1000, belres=1e-6)`

--- a/src/docs.jl
+++ b/src/docs.jl
@@ -25,12 +25,6 @@ ValueIterationPolicy
 
 
 """
-Returns an empty policy
-"""
-create_policy
-
-
-"""
 Computes the optimal policy for an MDP. The function takes a verbose flag which can dump text output onto the screen.
 You can run the function:
     `policy = solve(solver, mdp, verbose=true)`

--- a/src/vanilla.jl
+++ b/src/vanilla.jl
@@ -102,8 +102,13 @@ end
 # policy = ValueIterationPolicy(mdp)
 # solve(solver, mdp, policy, verbose=true)
 #####################################################################
-function solve(solver::ValueIterationSolver, mdp::Union{MDP,POMDP})
-
+function solve(solver::ValueIterationSolver, mdp::Union{MDP,POMDP}; kwargs...)
+    
+    # deprecation warning - can be removed when Julia 1.0 is adopted
+    if !isempty(kwargs)
+        warn("Keyword args for solve(::ValueIterationSolver, ::MDP) are no longer supported. For verbose output, use the verbose option in the ValueIterationSolver")
+    end
+    
     @warn_requirements solve(solver, mdp)
 
     # solver parameters

--- a/src/vanilla.jl
+++ b/src/vanilla.jl
@@ -27,26 +27,16 @@ end
 
 # constructor with an optinal initial value function argument
 function ValueIterationPolicy(mdp::Union{MDP,POMDP};
-                              utility::Vector{Float64}=Vector{Float64}(0),
-                              policy::Vector{Int64}=Vector{Int64}(0),
+                              utility::Vector{Float64}=zeros(n_states(mdp)),
+                              policy::Vector{Int64}=zeros(Int64, n_states(mdp)),
                               include_Q::Bool=true)
     ns = n_states(mdp)
     na = n_actions(mdp)
-    if !isempty(utility)
-        @assert length(utility) == ns "Input utility dimension mismatch"
-        util = utility
-    else
-        util = zeros(ns)
-    end
+    @assert length(utility) == ns "Input utility dimension mismatch"
+    @assert length(policy) == ns "Input policy dimension mismatch"
     action_map = ordered_actions(mdp)
-    if !isempty(policy)
-        @assert length(policy) == ns "Input policy dimension mismatch"
-        pol = policy
-    else
-        pol = zeros(Int64,ns)
-    end
     include_Q ? qmat = zeros(ns,na) : qmat = zeros(0,0)
-    return ValueIterationPolicy(qmat, util, pol, action_map, include_Q, mdp)
+    return ValueIterationPolicy(qmat, utility, policy, action_map, include_Q, mdp)
 end
 
 # constructor for solved q, util and policy

--- a/src/vanilla.jl
+++ b/src/vanilla.jl
@@ -33,14 +33,14 @@ function ValueIterationPolicy(mdp::Union{MDP,POMDP};
     ns = n_states(mdp)
     na = n_actions(mdp)
     if !isempty(utility)
-        @assert first(size(utility)) == ns "Input utility dimension mismatch"
+        @assert length(utility) == ns "Input utility dimension mismatch"
         util = utility
     else
         util = zeros(ns)
     end
     action_map = ordered_actions(mdp)
     if !isempty(policy)
-        @assert first(size(utility)) == ns "Input utility dimension mismatch"
+        @assert length(policy) == ns "Input policy dimension mismatch"
         pol = policy
     else
         pol = zeros(Int64,ns)

--- a/test/runtests_basic_value_iteration.jl
+++ b/test/runtests_basic_value_iteration.jl
@@ -1,9 +1,8 @@
 
 function support_serial_qtest(mdp::Union{MDP,POMDP}, file::AbstractString; niter::Int64=100, res::Float64=1e-3)
     qt = readdlm(file)
-    solver = ValueIterationSolver(max_iterations=niter, belres=res)
-    policy = create_policy(solver, mdp) 
-    policy = solve(solver, mdp, policy, verbose=true)
+    solver = ValueIterationSolver(max_iterations=niter, belres=res, verbose=true)
+    policy = solve(solver, mdp)
     (q, u, p, am) = locals(policy)
     npolicy = ValueIterationPolicy(mdp, deepcopy(q))
     nnpolicy = ValueIterationPolicy(mdp, deepcopy(q), deepcopy(u), deepcopy(p))
@@ -43,9 +42,8 @@ function test_simple_grid()
 	# 7 (0,0) is absorbing state
 	mdp = GridWorld(sx=2, sy=3, rs = [GridWorldState(2,3)], rv = [10.0])
 	
-	solver = ValueIterationSolver()
-    policy = create_policy(solver, mdp) 
-    policy = solve(solver, mdp, policy, verbose=true)
+	solver = ValueIterationSolver(verbose=true)
+    policy = solve(solver, mdp)
 
 	# up: 1, down: 2, left: 3, right: 4
 	correct_policy = [1,1,1,1,4,1,1] # alternative policies

--- a/test/runtests_basic_value_iteration.jl
+++ b/test/runtests_basic_value_iteration.jl
@@ -67,6 +67,22 @@ function test_init_solution()
 	return isapprox(ut, policy.util, rtol=1e-5)
 end
 
+function test_not_include_Q()
+	# Load correct policy from file and verify we can reconstruct it
+	rstates = [GridWorldState(4,3), GridWorldState(4,6), GridWorldState(9,3), GridWorldState(8,8)]
+	rvals = [-10.0, -5.0, 10.0, 3.0]
+	xs = 10
+	ys = 10
+	mdp = GridWorld(sx=xs, sy=ys, rs = rstates, rv = rvals)
+	qt = readdlm("grid-world-10x10-Q-matrix.txt")
+	ut = maximum(qt, 2)[:]
+	niter = 100
+	res = 1e-3
+	solver = ValueIterationSolver(verbose=true, init_util=ut, belres=1e-3, include_Q=false)
+	policy = solve(solver, mdp)
+	return isapprox(ut, policy.util, rtol=1e-3)
+end
+
 @test test_complex_gridworld() == true
 @test test_simple_grid() == true
 @test test_init_solution() == true

--- a/test/runtests_basic_value_iteration.jl
+++ b/test/runtests_basic_value_iteration.jl
@@ -83,7 +83,15 @@ function test_not_include_Q()
     return isapprox(ut, policy.util, rtol=1e-3)
 end
 
+function test_warning()
+    mdp = GridWorld()
+    solver = ValueIterationSolver()
+    println("There should be a warning bellow: ")
+    solve(solver, mdp, verbose=true)
+end
+
 @test test_complex_gridworld() == true
 @test test_simple_grid() == true
 @test test_init_solution() == true
 @test test_not_include_Q() == true
+test_warning()

--- a/test/runtests_basic_value_iteration.jl
+++ b/test/runtests_basic_value_iteration.jl
@@ -53,5 +53,20 @@ function test_simple_grid()
 	return policy.policy == correct_policy
 end
 
+function test_init_solution()
+	# Initialize the value to the solution 
+	rstates = [GridWorldState(4,3), GridWorldState(4,6), GridWorldState(9,3), GridWorldState(8,8)]
+	rvals = [-10.0, -5.0, 10.0, 3.0]
+	xs = 10
+	ys = 10
+	mdp = GridWorld(sx=xs, sy=ys, rs = rstates, rv = rvals)
+	qt = readdlm("grid-world-10x10-Q-matrix.txt")
+	ut = maximum(qt, 2)[:]
+	solver = ValueIterationSolver(verbose=true, init_util=ut, belres=1e-3)
+	policy = solve(solver, mdp)
+	return isapprox(ut, policy.util, rtol=1e-5)
+end
+
 @test test_complex_gridworld() == true
 @test test_simple_grid() == true
+@test test_init_solution() == true

--- a/test/runtests_basic_value_iteration.jl
+++ b/test/runtests_basic_value_iteration.jl
@@ -86,3 +86,4 @@ end
 @test test_complex_gridworld() == true
 @test test_simple_grid() == true
 @test test_init_solution() == true
+@test test_not_include_Q() == true

--- a/test/runtests_basic_value_iteration.jl
+++ b/test/runtests_basic_value_iteration.jl
@@ -16,71 +16,71 @@ end
 
 
 function test_complex_gridworld()
-	# Load correct policy from file and verify we can reconstruct it
-	rstates = [GridWorldState(4,3), GridWorldState(4,6), GridWorldState(9,3), GridWorldState(8,8)]
-	rvals = [-10.0, -5.0, 10.0, 3.0]
-	xs = 10
-	ys = 10
-	mdp = GridWorld(sx=xs, sy=ys, rs = rstates, rv = rvals)
-	file = "grid-world-10x10-Q-matrix.txt"
-	niter = 100
-	res = 1e-3
+    # Load correct policy from file and verify we can reconstruct it
+    rstates = [GridWorldState(4,3), GridWorldState(4,6), GridWorldState(9,3), GridWorldState(8,8)]
+    rvals = [-10.0, -5.0, 10.0, 3.0]
+    xs = 10
+    ys = 10
+    mdp = GridWorld(sx=xs, sy=ys, rs = rstates, rv = rvals)
+    file = "grid-world-10x10-Q-matrix.txt"
+    niter = 100
+    res = 1e-3
 
-	return support_serial_qtest(mdp, file, niter=niter, res=res)
+    return support_serial_qtest(mdp, file, niter=niter, res=res)
 end
 
 function test_simple_grid()
-	# Simple test....
-	# GridWorld(sx=2,sy=3) w reward at (2,3):
-	# Here's our grid:
-	# |state (x,y)____available actions__|
-	# ----------------------------------------------
-	# |5 (1,3)__u,d,l,r__|6 (2,3)__u,d,l,r+REWARD__|
-	# |3 (1,2)__u,d,l,r__|4 (2,2)______u,d,l,r_____|
-	# |1 (1,1)__u,d,l,r__|2 (2,1)______u,d,l,r_____|
-	# ----------------------------------------------
-	# 7 (0,0) is absorbing state
-	mdp = GridWorld(sx=2, sy=3, rs = [GridWorldState(2,3)], rv = [10.0])
-	
-	solver = ValueIterationSolver(verbose=true)
+    # Simple test....
+    # GridWorld(sx=2,sy=3) w reward at (2,3):
+    # Here's our grid:
+    # |state (x,y)____available actions__|
+    # ----------------------------------------------
+    # |5 (1,3)__u,d,l,r__|6 (2,3)__u,d,l,r+REWARD__|
+    # |3 (1,2)__u,d,l,r__|4 (2,2)______u,d,l,r_____|
+    # |1 (1,1)__u,d,l,r__|2 (2,1)______u,d,l,r_____|
+    # ----------------------------------------------
+    # 7 (0,0) is absorbing state
+    mdp = GridWorld(sx=2, sy=3, rs = [GridWorldState(2,3)], rv = [10.0])
+    
+    solver = ValueIterationSolver(verbose=true)
     policy = solve(solver, mdp)
 
-	# up: 1, down: 2, left: 3, right: 4
-	correct_policy = [1,1,1,1,4,1,1] # alternative policies
-	# are possible, but since they are tied & the first 
-	# action is always 1, we will always return 1 for tied
-	# actions
-	return policy.policy == correct_policy
+    # up: 1, down: 2, left: 3, right: 4
+    correct_policy = [1,1,1,1,4,1,1] # alternative policies
+    # are possible, but since they are tied & the first 
+    # action is always 1, we will always return 1 for tied
+    # actions
+    return policy.policy == correct_policy
 end
 
 function test_init_solution()
-	# Initialize the value to the solution 
-	rstates = [GridWorldState(4,3), GridWorldState(4,6), GridWorldState(9,3), GridWorldState(8,8)]
-	rvals = [-10.0, -5.0, 10.0, 3.0]
-	xs = 10
-	ys = 10
-	mdp = GridWorld(sx=xs, sy=ys, rs = rstates, rv = rvals)
-	qt = readdlm("grid-world-10x10-Q-matrix.txt")
-	ut = maximum(qt, 2)[:]
-	solver = ValueIterationSolver(verbose=true, init_util=ut, belres=1e-3)
-	policy = solve(solver, mdp)
-	return isapprox(ut, policy.util, rtol=1e-5)
+    # Initialize the value to the solution 
+    rstates = [GridWorldState(4,3), GridWorldState(4,6), GridWorldState(9,3), GridWorldState(8,8)]
+    rvals = [-10.0, -5.0, 10.0, 3.0]
+    xs = 10
+    ys = 10
+    mdp = GridWorld(sx=xs, sy=ys, rs = rstates, rv = rvals)
+    qt = readdlm("grid-world-10x10-Q-matrix.txt")
+    ut = maximum(qt, 2)[:]
+    solver = ValueIterationSolver(verbose=true, init_util=ut, belres=1e-3)
+    policy = solve(solver, mdp)
+    return isapprox(ut, policy.util, rtol=1e-5)
 end
 
 function test_not_include_Q()
-	# Load correct policy from file and verify we can reconstruct it
-	rstates = [GridWorldState(4,3), GridWorldState(4,6), GridWorldState(9,3), GridWorldState(8,8)]
-	rvals = [-10.0, -5.0, 10.0, 3.0]
-	xs = 10
-	ys = 10
-	mdp = GridWorld(sx=xs, sy=ys, rs = rstates, rv = rvals)
-	qt = readdlm("grid-world-10x10-Q-matrix.txt")
-	ut = maximum(qt, 2)[:]
-	niter = 100
-	res = 1e-3
-	solver = ValueIterationSolver(verbose=true, init_util=ut, belres=1e-3, include_Q=false)
-	policy = solve(solver, mdp)
-	return isapprox(ut, policy.util, rtol=1e-3)
+    # Load correct policy from file and verify we can reconstruct it
+    rstates = [GridWorldState(4,3), GridWorldState(4,6), GridWorldState(9,3), GridWorldState(8,8)]
+    rvals = [-10.0, -5.0, 10.0, 3.0]
+    xs = 10
+    ys = 10
+    mdp = GridWorld(sx=xs, sy=ys, rs = rstates, rv = rvals)
+    qt = readdlm("grid-world-10x10-Q-matrix.txt")
+    ut = maximum(qt, 2)[:]
+    niter = 100
+    res = 1e-3
+    solver = ValueIterationSolver(verbose=true, init_util=ut, belres=1e-3, include_Q=false)
+    policy = solve(solver, mdp)
+    return isapprox(ut, policy.util, rtol=1e-3)
 end
 
 @test test_complex_gridworld() == true

--- a/test/runtests_basic_value_iteration_disallowing_actions.jl
+++ b/test/runtests_basic_value_iteration_disallowing_actions.jl
@@ -16,50 +16,50 @@ POMDPs.actions(g::SpecialGridWorld) = actions(g.gw)
 # Let's extend actions to hard-code & limit to the
 # particular feasible actions from each state....
 function POMDPs.actions(mdp::SpecialGridWorld, s::GridWorldState)
-	# up: 1, down: 2, left: 3, right: 4
-	sidx = state_index(mdp, s)
-	if sidx == 1
-		acts = [GridWorldAction(:left), GridWorldAction(:right)]
-	elseif sidx == 2
-		acts = [GridWorldAction(:up), GridWorldAction(:right)]
-	elseif sidx == 3
-		acts = [GridWorldAction(:left), GridWorldAction(:up)]
-	elseif sidx == 4
-		acts = [GridWorldAction(:left), GridWorldAction(:right)]
-	elseif sidx == 5
-		acts = [GridWorldAction(:left), GridWorldAction(:right)]
-	elseif sidx == 6
-		acts = [GridWorldAction(:up), GridWorldAction(:down), GridWorldAction(:left), GridWorldAction(:right)]
-	elseif sidx == 7
-		acts = [GridWorldAction(:up), GridWorldAction(:down), GridWorldAction(:left), GridWorldAction(:right)]
-	end
-	return acts
+    # up: 1, down: 2, left: 3, right: 4
+    sidx = state_index(mdp, s)
+    if sidx == 1
+        acts = [GridWorldAction(:left), GridWorldAction(:right)]
+    elseif sidx == 2
+        acts = [GridWorldAction(:up), GridWorldAction(:right)]
+    elseif sidx == 3
+        acts = [GridWorldAction(:left), GridWorldAction(:up)]
+    elseif sidx == 4
+        acts = [GridWorldAction(:left), GridWorldAction(:right)]
+    elseif sidx == 5
+        acts = [GridWorldAction(:left), GridWorldAction(:right)]
+    elseif sidx == 6
+        acts = [GridWorldAction(:up), GridWorldAction(:down), GridWorldAction(:left), GridWorldAction(:right)]
+    elseif sidx == 7
+        acts = [GridWorldAction(:up), GridWorldAction(:down), GridWorldAction(:left), GridWorldAction(:right)]
+    end
+    return acts
 end
 
 
 function test_conditioning_actions_on_state()
-	# Condition available actions on next state....
-	# GridWorld(sx=2,sy=3) w reward at (2,3):
-	#
-	# Here's our grid, with some actions missing:
-	#
-	# |state (x,y)____available actions__|
-	# |5 (1,3)__l,r__|6 (2,3)__u,d,l,r+REWARD__|
-	# |3 (1,2)__l,u__|4 (2,2)_______l,r________|
-	# |1 (1,1)__l,r__|2 (2,1)_______u,r________|
-	# 7 (0,0) is absorbing state
+    # Condition available actions on next state....
+    # GridWorld(sx=2,sy=3) w reward at (2,3):
+    #
+    # Here's our grid, with some actions missing:
+    #
+    # |state (x,y)____available actions__|
+    # |5 (1,3)__l,r__|6 (2,3)__u,d,l,r+REWARD__|
+    # |3 (1,2)__l,u__|4 (2,2)_______l,r________|
+    # |1 (1,1)__l,r__|2 (2,1)_______u,r________|
+    # 7 (0,0) is absorbing state
     mdp = SpecialGridWorld(GridWorld(sx=2, sy=3, rs = [GridWorldState(2,3)], rv = [10.0]))
 
-	solver = ValueIterationSolver(verbose=true)
+    solver = ValueIterationSolver(verbose=true)
     policy = solve(solver, mdp)
 
-	println(policy.policy)
+    println(policy.policy)
 
-	# up: 1, down: 2, left: 3, right: 4
-	correct_policy = [4,1,1,3,4,1,1] # alternative policies
-	# for state 6 are possible, but since they are ordered
-	# such that 1 comes first, 1 will always be the policy
-	return policy.policy == correct_policy
+    # up: 1, down: 2, left: 3, right: 4
+    correct_policy = [4,1,1,3,4,1,1] # alternative policies
+    # for state 6 are possible, but since they are ordered
+    # such that 1 comes first, 1 will always be the policy
+    return policy.policy == correct_policy
 end
 
 @test test_conditioning_actions_on_state() == true

--- a/test/runtests_basic_value_iteration_disallowing_actions.jl
+++ b/test/runtests_basic_value_iteration_disallowing_actions.jl
@@ -50,9 +50,8 @@ function test_conditioning_actions_on_state()
 	# 7 (0,0) is absorbing state
     mdp = SpecialGridWorld(GridWorld(sx=2, sy=3, rs = [GridWorldState(2,3)], rv = [10.0]))
 
-	solver = ValueIterationSolver()
-    policy = create_policy(solver, mdp)
-    policy = solve(solver, mdp, policy, verbose=true)
+	solver = ValueIterationSolver(verbose=true)
+    policy = solve(solver, mdp)
 
 	println(policy.policy)
 

--- a/test/runtests_value_iteration_policy.jl
+++ b/test/runtests_value_iteration_policy.jl
@@ -46,6 +46,19 @@ function test_creation_of_policy_given_q()
 	return (policy.mdp == mdp && policy.qmat == correct_qmat)
 end
 
+function test_creation_of_policy_given_policy()
+		# If we create a ValueIterationPolicy by providing a policy,
+	# does those values successfully get saved?
+	#
+	# GridWorld:
+	# |_________|_________|_________| plus a fake state for absorbing
+	mdp = GridWorld(sx=1, sy=3, rs = [GridWorldState(1,3)], rv = [10.0])
+	correct_policy = [1,1,1,1]
+	policy = ValueIterationPolicy(mdp, policy=correct_policy)
+	return policy.policy == correct_policy
+end
+
 @test test_creation_of_policy_given_utilities() == true
 @test test_creation_of_policy_given_q_util_policy() == true
 @test test_creation_of_policy_given_q() == true
+@test test_creation_of_policy_given_policy() == true

--- a/test/runtests_value_iteration_policy.jl
+++ b/test/runtests_value_iteration_policy.jl
@@ -1,61 +1,61 @@
 
 function test_creation_of_policy_given_utilities()
-	# If we create a ValueIterationPolicy by providing a utility,
-	# does that utility successfully get saved?
-	#
-	# GridWorld:
-	# |_________|_________|_________| plus a fake state for absorbing
-	mdp = GridWorld(sx=1, sy=3, rs = [GridWorldState(1,3)], rv = [10.0])
-	# Create a starter set of utilities 
-	# 0.0 is associated with the fake absorbing state
-	correct_utility = [5.45632, 8.20505, 10.0, 0.0] 
+    # If we create a ValueIterationPolicy by providing a utility,
+    # does that utility successfully get saved?
+    #
+    # GridWorld:
+    # |_________|_________|_________| plus a fake state for absorbing
+    mdp = GridWorld(sx=1, sy=3, rs = [GridWorldState(1,3)], rv = [10.0])
+    # Create a starter set of utilities 
+    # 0.0 is associated with the fake absorbing state
+    correct_utility = [5.45632, 8.20505, 10.0, 0.0] 
 
-	# Derive a policy & check that they match	
-	policy = ValueIterationPolicy(mdp, utility=correct_utility, include_Q=true)
-	return policy.mdp == mdp && policy.util == correct_utility
+    # Derive a policy & check that they match  
+    policy = ValueIterationPolicy(mdp, utility=correct_utility, include_Q=true)
+    return policy.mdp == mdp && policy.util == correct_utility
 end
 
 
 function test_creation_of_policy_given_q_util_policy()
-	# If we create a ValueIterationPolicy by providing a utility, q, and policy,
-	# does those values successfully get saved?
-	#
-	# GridWorld:
-	# |_________|_________|_________| plus a fake state for absorbing
-	mdp = GridWorld(sx=1, sy=3, rs = [GridWorldState(1,3)], rv = [10.0])
-	correct_utility = [5.45632, 8.20505, 10.0, 0.0] 
-	correct_qmat = [5.45636 5.1835 5.1835 5.1835; 8.20506 6.47848 7.7948 7.7948; 10.0 10.0 10.0 10.0; 0.0 0.0 0.0 0.0]
-	correct_policy = [1,1,1,1]
-	
-	# Derive a policy & check that they match	
-	policy = ValueIterationPolicy(mdp, correct_qmat, correct_utility, correct_policy)
-	return (policy.mdp == mdp && policy.qmat == correct_qmat && policy.util == correct_utility && policy.policy == correct_policy && policy.include_Q == true)
+    # If we create a ValueIterationPolicy by providing a utility, q, and policy,
+    # does those values successfully get saved?
+    #
+    # GridWorld:
+    # |_________|_________|_________| plus a fake state for absorbing
+    mdp = GridWorld(sx=1, sy=3, rs = [GridWorldState(1,3)], rv = [10.0])
+    correct_utility = [5.45632, 8.20505, 10.0, 0.0] 
+    correct_qmat = [5.45636 5.1835 5.1835 5.1835; 8.20506 6.47848 7.7948 7.7948; 10.0 10.0 10.0 10.0; 0.0 0.0 0.0 0.0]
+    correct_policy = [1,1,1,1]
+    
+    # Derive a policy & check that they match  
+    policy = ValueIterationPolicy(mdp, correct_qmat, correct_utility, correct_policy)
+    return (policy.mdp == mdp && policy.qmat == correct_qmat && policy.util == correct_utility && policy.policy == correct_policy && policy.include_Q == true)
 end
 
 function test_creation_of_policy_given_q()
-	# If we create a ValueIterationPolicy by providing a default q,
-	# does its value successfully get saved?
-	#
-	# GridWorld:
-	# |_________|_________|_________| plus a fake state for absorbing
-	mdp = GridWorld(sx=1, sy=3, rs = [GridWorldState(1,3)], rv = [10.0])
-	correct_qmat = [5.45636 5.1835 5.1835 5.1835; 8.20506 6.47848 7.7948 7.7948; 10.0 10.0 10.0 10.0; 0.0 0.0 0.0 0.0]
-	
-	# Derive a policy & check that they match	
-	policy = ValueIterationPolicy(mdp, correct_qmat)
-	return (policy.mdp == mdp && policy.qmat == correct_qmat)
+    # If we create a ValueIterationPolicy by providing a default q,
+    # does its value successfully get saved?
+    #
+    # GridWorld:
+    # |_________|_________|_________| plus a fake state for absorbing
+    mdp = GridWorld(sx=1, sy=3, rs = [GridWorldState(1,3)], rv = [10.0])
+    correct_qmat = [5.45636 5.1835 5.1835 5.1835; 8.20506 6.47848 7.7948 7.7948; 10.0 10.0 10.0 10.0; 0.0 0.0 0.0 0.0]
+    
+    # Derive a policy & check that they match  
+    policy = ValueIterationPolicy(mdp, correct_qmat)
+    return (policy.mdp == mdp && policy.qmat == correct_qmat)
 end
 
 function test_creation_of_policy_given_policy()
-		# If we create a ValueIterationPolicy by providing a policy,
-	# does those values successfully get saved?
-	#
-	# GridWorld:
-	# |_________|_________|_________| plus a fake state for absorbing
-	mdp = GridWorld(sx=1, sy=3, rs = [GridWorldState(1,3)], rv = [10.0])
-	correct_policy = [1,1,1,1]
-	policy = ValueIterationPolicy(mdp, policy=correct_policy)
-	return policy.policy == correct_policy
+    # If we create a ValueIterationPolicy by providing a policy,
+    # does those values successfully get saved?
+    #
+    # GridWorld:
+    # |_________|_________|_________| plus a fake state for absorbing
+    mdp = GridWorld(sx=1, sy=3, rs = [GridWorldState(1,3)], rv = [10.0])
+    correct_policy = [1,1,1,1]
+    policy = ValueIterationPolicy(mdp, policy=correct_policy)
+    return policy.policy == correct_policy
 end
 
 @test test_creation_of_policy_given_utilities() == true


### PR DESCRIPTION
This PR addresses #9 

- `create_policy` no longer exists
- `ValueIterationPolicy` has outer constructors rather than inner ones. 
- the solve method is `solve(solver, mdp)`
- the solver type has new fields: `verbose`, `include_Q` and `init_util`