### PR TITLE
Add Cached Sparse Solver

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ POMDPModelTools = "08074719-1b2a-587c-a292-00f91cc44415"
 POMDPPolicies = "182e52fb-cfd0-5e46-8c26-fd0667c990f4"
 POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/README.md
+++ b/README.md
@@ -5,17 +5,22 @@
 
 This package implements the discrete value iteration algorithm in Julia for solving Markov decision processes (MDPs).
 The user should define the problem according to the API in [POMDPs.jl](https://github.com/JuliaPOMDP/POMDPs.jl). Examples of
-problem definitions can be found in [POMDPModels.jl](https://github.com/JuliaPOMDP/POMDPModels.jl). For an extensive tutorial, see the [this](http://nbviewer.ipython.org/github/JuliaPOMDP/POMDPs.jl/blob/master/examples/GridWorld.ipynb) notebook.
+problem definitions can be found in [POMDPModels.jl](https://github.com/JuliaPOMDP/POMDPModels.jl). For an extensive tutorial, see the [these](https://github.com/JuliaPOMDP/POMDPExamples.jl) notebooks.
 
 ## Installation
 
-Start Julia and run the following command:
+Start Julia and make sure you have the JuliaPOMDP registry:
 
 ```julia
-using POMDPs
-POMDPs.add("DiscreteValueIteration")
+import POMDPs
+POMDPs.add_registry()
 ```
 
+Then install using the standard package manager:
+
+```julia
+using Pkg; Pkg.add("DiscreteValueIteration")
+```
 
 ## Usage
 
@@ -25,6 +30,7 @@ Use
 using POMDPs
 using DiscreteValueIteration
 @requirements_info ValueIterationSolver() YourMDP()
+@requirements_info SparseValueIterationSolver() YourMDP()
 ```
 
 to get a list of POMDPs.jl functions necessary to use the solver. This should return a list of the following functions to be implemented for your MDP:
@@ -57,5 +63,5 @@ solve(solver, mdp) # runs value iterations
 To extract the policy for a given state, simply call the action function:
 
 ```julia
-a = action(polciy, s) # returns the optimal action for state s
+a = action(policy, s) # returns the optimal action for state s
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This package implements the discrete value iteration algorithm in Julia for solv
 The user should define the problem according to the API in [POMDPs.jl](https://github.com/JuliaPOMDP/POMDPs.jl). Examples of
 problem definitions can be found in [POMDPModels.jl](https://github.com/JuliaPOMDP/POMDPModels.jl). For an extensive tutorial, see [these](https://github.com/JuliaPOMDP/POMDPExamples.jl) notebooks.
 
-There are two solvers in the package. The "vanilla" `ValueIterationSolver` calls functions from the POMDPs.jl interface in every iteration, while the `SparseValueIterationSolver` first creates sparse transition and reward matrices and then performs value iteration with the new matrix representation. While both solvers take advantage of sparsity, the `SparseValueIterationSolver` is generally faster because of low-level optimizations, while the `ValueIterationSolver` has the advantage that it does not require allocation of transition matrices (which could potentially be too large to fit in memory).
+There are two solvers in the package. The "vanilla" [`ValueIterationSolver`](src/vanilla.jl) calls functions from the POMDPs.jl interface in every iteration, while the [`SparseValueIterationSolver`](src/sparse.jl) first creates sparse transition and reward matrices and then performs value iteration with the new matrix representation. While both solvers take advantage of sparsity, the `SparseValueIterationSolver` is generally faster because of low-level optimizations, while the `ValueIterationSolver` has the advantage that it does not require allocation of transition matrices (which could potentially be too large to fit in memory).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This package implements the discrete value iteration algorithm in Julia for solv
 The user should define the problem according to the API in [POMDPs.jl](https://github.com/JuliaPOMDP/POMDPs.jl). Examples of
 problem definitions can be found in [POMDPModels.jl](https://github.com/JuliaPOMDP/POMDPModels.jl). For an extensive tutorial, see [these](https://github.com/JuliaPOMDP/POMDPExamples.jl) notebooks.
 
+There are two solvers in the package. The "vanilla" `ValueIterationSolver` calls functions from the POMDPs.jl interface in every iteration, while the `SparseValueIterationSolver` first creates sparse transition and reward matrices and then performs value iteration with the new matrix representation. While both solvers take advantage of sparsity, the `SparseValueIterationSolver` is generally faster because of low-level optimizations, while the `ValueIterationSolver` has the advantage that it does not require allocation of transition matrices (which could potentially be too large to fit in memory).
+
 ## Installation
 
 Start Julia and make sure you have the JuliaPOMDP registry:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This package implements the discrete value iteration algorithm in Julia for solving Markov decision processes (MDPs).
 The user should define the problem according to the API in [POMDPs.jl](https://github.com/JuliaPOMDP/POMDPs.jl). Examples of
-problem definitions can be found in [POMDPModels.jl](https://github.com/JuliaPOMDP/POMDPModels.jl). For an extensive tutorial, see the [these](https://github.com/JuliaPOMDP/POMDPExamples.jl) notebooks.
+problem definitions can be found in [POMDPModels.jl](https://github.com/JuliaPOMDP/POMDPModels.jl). For an extensive tutorial, see [these](https://github.com/JuliaPOMDP/POMDPExamples.jl) notebooks.
 
 ## Installation
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.7
 POMDPs
 POMDPModelTools
 POMDPPolicies
+SparseArrays

--- a/benchmark/vvsparse.jl
+++ b/benchmark/vvsparse.jl
@@ -6,14 +6,14 @@ using BenchmarkTools
 
 function bench_sparsevi(size)
     world = SimpleGridWorld(size=size)
-    solver = SparseValueIterationSolver(max_iterations=500, belres=1e-4)
+    solver = SparseValueIterationSolver(max_iterations=500, belres=0.0)
     policy = solve(solver, world)
     return policy
 end
 
 function bench_vanillavi(size)
     world = SimpleGridWorld(size=size)
-    solver = ValueIterationSolver(max_iterations=500, belres=1e-4)
+    solver = ValueIterationSolver(max_iterations=500, belres=0.0)
     policy = solve(solver, world)
     return policy
 end

--- a/benchmark/vvsparse.jl
+++ b/benchmark/vvsparse.jl
@@ -1,0 +1,27 @@
+using POMDPs
+using POMDPModels
+using DiscreteValueIteration
+
+using BenchmarkTools
+
+function bench_sparsevi(size)
+    world = SimpleGridWorld(size=size)
+    solver = SparseValueIterationSolver(max_iterations=500, belres=1e-4)
+    policy = solve(solver, world)
+    return policy
+end
+
+function bench_vanillavi(size)
+    world = SimpleGridWorld(size=size)
+    solver = ValueIterationSolver(max_iterations=500, belres=1e-4)
+    policy = solve(solver, world)
+    return policy
+end
+
+for size in [(10,10), (100, 100), (1000, 1000), (10000, 10000)]
+    @show size
+    @info "Sparse"
+    @btime bench_sparsevi($size)
+    @info "Vanilla"
+    @btime bench_vanillavi($size)
+end

--- a/src/DiscreteValueIteration.jl
+++ b/src/DiscreteValueIteration.jl
@@ -14,7 +14,6 @@ import POMDPs: Solver, solve, Policy, action, value
 export
     ValueIterationPolicy,
     ValueIterationSolver,
-    SparseVIPolicy,
     SparseValueIterationSolver,
     solve,
     action,

--- a/src/DiscreteValueIteration.jl
+++ b/src/DiscreteValueIteration.jl
@@ -7,18 +7,22 @@ using Printf
 using POMDPs
 using POMDPModelTools
 using POMDPPolicies
+using SparseArrays
 
 import POMDPs: Solver, solve, Policy, action, value 
 
 export
     ValueIterationPolicy,
     ValueIterationSolver,
+    SparseVIPolicy,
+    SparseValueIterationSolver,
     solve,
     action,
     value,
     locals
 
 include("vanilla.jl")
+include("sparse.jl")
 include("docs.jl")
 
 end # module

--- a/src/DiscreteValueIteration.jl
+++ b/src/DiscreteValueIteration.jl
@@ -21,6 +21,7 @@ export
     value,
     locals
 
+include("common.jl")
 include("vanilla.jl")
 include("sparse.jl")
 include("docs.jl")

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,0 +1,69 @@
+# The policy type
+mutable struct ValueIterationPolicy{F} <: Policy
+    qmat::AbstractMatrix{F} # Q matrix storing Q(s,a) values
+    util::AbstractVector{F} # The value function V(s)
+    policy::AbstractVector{Int64} # Policy array, maps state index to action index
+    action_map::Vector # Maps the action index to the concrete action type
+    include_Q::Bool # Flag for including the Q-matrix
+    mdp::Union{MDP,POMDP} # uses the model for indexing in the action function
+end
+
+# constructor with an optinal initial value function argument
+function ValueIterationPolicy(mdp::Union{MDP,POMDP};
+                              utility::AbstractVector{Float64}=zeros(n_states(mdp)),
+                              policy::AbstractVector{Int64}=zeros(Int64, n_states(mdp)),
+                              include_Q::Bool=true)
+    ns = n_states(mdp)
+    na = n_actions(mdp)
+    @assert length(utility) == ns "Input utility dimension mismatch"
+    @assert length(policy) == ns "Input policy dimension mismatch"
+    action_map = ordered_actions(mdp)
+    include_Q ? qmat = zeros(ns,na) : qmat = zeros(0,0)
+    return ValueIterationPolicy(qmat, utility, policy, action_map, include_Q, mdp)
+end
+
+# constructor for solved q, util and policy
+function ValueIterationPolicy(mdp::Union{MDP,POMDP}, q::AbstractMatrix{F}, util::AbstractVector{F}, policy::Vector{Int64}) where {F}
+    action_map = ordered_actions(mdp)
+    include_Q = true
+    return ValueIterationPolicy(q, util, policy, action_map, include_Q, mdp)
+end
+
+# constructor for default Q-matrix
+function ValueIterationPolicy(mdp::Union{MDP,POMDP}, q::AbstractMatrix{F}) where {F}
+    (ns, na) = size(q)
+    p = zeros(Int64, ns)
+    u = zeros(ns)
+    for i = 1:ns
+        p[i] = argmax(q[i,:])
+        u[i] = maximum(q[i,:])
+    end
+    action_map = ordered_actions(mdp)
+    include_Q = true
+    return ValueIterationPolicy(q, u, p, action_map, include_Q, mdp)
+end
+
+# returns the fields of the policy type
+function locals(p::ValueIterationPolicy)
+    return (p.qmat,p.util,p.policy,p.action_map)
+end
+
+function action(policy::ValueIterationPolicy, s::S) where S
+    sidx = stateindex(policy.mdp, s)
+    aidx = policy.policy[sidx]
+    return policy.action_map[aidx]
+end
+
+function value(policy::ValueIterationPolicy, s::S) where S
+    sidx = stateindex(policy.mdp, s)
+    policy.util[sidx]
+end
+
+function POMDPPolicies.actionvalues(policy::ValueIterationPolicy, s::S) where S
+    if !policy.include_Q
+        error("ValueIterationPolicyError: the policy does not contain the Q function!")
+    else
+        sidx = stateindex(policy.mdp, s)
+        return policy.qmat[sidx,:]
+    end
+end

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -41,7 +41,7 @@ end
 function qvalue!(m::Union{MDP,POMDP}, transition_A_S_S2, reward_S_A::AbstractMatrix{F}, value_S::AbstractVector{F}, out_qvals_S_A) where {F}
     @assert size(out_qvals_S_A) == (n_states(m), n_actions(m))
     for a in 1:n_actions(m)
-        out_qvals_S_A[:, a] = reward_S_A[:, a] + discount(m) * transition_A_S_S2[a] * value_S
+        out_qvals_S_A[:, a] = view(reward_S_A, :, a) + discount(m) * transition_A_S_S2[a] * value_S
     end
 end
 

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -77,21 +77,17 @@ function transition_matrix_a_s_sp(mdp::MDP)
 end
 
 function reward_s_a(mdp::MDP)
-    reward_S_A = zeros(n_states(mdp), n_actions(mdp))
+    reward_S_A = fill(-Inf, (n_states(mdp), n_actions(mdp))) # set reward for all actions to -Inf unless they are in actions(mdp, s)
     for s in states(mdp)
-        for a in actions(mdp)
-            if @implemented(reward(::typeof(mdp), ::typeof(s), ::typeof(s)))
-                reward_S_A[stateindex(mdp, s), actionindex(mdp, a)] = reward(mdp, s, a)
-            else
-                td = transition(mdp, s, a)
-                r = 0.0
-                for (sp, p) in weighted_iterator(td)
-                    if p > 0.0
-                        r += p*reward(mdp, s, a, sp)
-                    end
+        for a in actions(mdp, s)
+            td = transition(mdp, s, a)
+            r = 0.0
+            for (sp, p) in weighted_iterator(td)
+                if p > 0.0
+                    r += p*reward(mdp, s, a, sp)
                 end
-                reward_S_A[stateindex(mdp, s), actionindex(mdp, a)] = r
             end
+            reward_S_A[stateindex(mdp, s), actionindex(mdp, a)] = r
         end
     end
     return reward_S_A

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -1,0 +1,157 @@
+struct SparseValueIterationSolver <: Solver
+    max_iterations::Int64
+    belres::Float64 # the Bellman Residual
+    verbose::Bool
+    init_util::Vector{Float64}
+end
+
+function SparseValueIterationSolver(;max_iterations=500,
+                                    belres::Float64 = 1e-3,
+                                    verbose::Bool=false,
+                                    init_util::Vector{Float64}=Vector{Float64}(undef, 0))
+    return SparseValueIterationSolver(max_iterations, belres, verbose, init_util)
+end
+
+struct SparseVIPolicy{F}
+    v_S::AbstractVector{F}
+    qvals_S_A::AbstractArray{F, 2}
+    policy_S::AbstractVector{Int}
+    action_map::Vector # Maps the action index to the concrete action type
+    mdp::Union{MDP,POMDP} # uses the model for indexing in the action function
+end
+
+function SparseVIPolicy(mdp::Union{MDP, POMDP}; utility::AbstractVector{Float64}=zeros(n_states(mdp)),
+                        policy::AbstractVector{Int64}=zeros(Int64, n_states(mdp)))
+    ns = n_states(mdp)
+    na = n_actions(mdp)
+    @assert length(utility) == ns "Input utility dimension mismatch"
+    @assert length(policy) == ns "Input policy dimension mismatch"
+    action_map = ordered_actions(mdp)
+    qmat = zeros(ns, na)
+    return SparseVIPolicy(utility, qmat, policy, action_map, mdp)
+end
+
+function SparseVIPolicy(mdp::Union{MDP, POMDP}, q::AbstractMatrix{Float64}, util::AbstractVector{Float64}, policy::AbstractVector{Int64})
+    action_map = ordered_actions(mdp)
+    return SparseVIPolicy(util, q, policy, action_map, mdp)
+end
+
+@POMDP_require solve(solver::SparseValueIterationSolver, mdp::Union{MDP,POMDP}) begin
+    P = typeof(mdp)
+    S = statetype(P)
+    A = actiontype(P)
+    @req discount(::P)
+    @req n_states(::P)
+    @req n_actions(::P)
+    @subreq ordered_states(mdp)
+    @subreq ordered_actions(mdp)
+    @req transition(::P,::S,::A)
+    @req reward(::P,::S,::A,::S)
+    @req stateindex(::P,::S)
+    @req actionindex(::P, ::A)
+    @req actions(::P, ::S)
+    as = actions(mdp)
+    ss = states(mdp)
+    a = first(as)
+    s = first(ss)
+    dist = transition(mdp, s, a)
+    D = typeof(dist)
+    @req support(::D)
+    @req pdf(::D,::S)
+end
+
+function qvalue!(m::Union{MDP,POMDP}, transition_A_S_S2, reward_S::AbstractVector{F}, value_S::AbstractVector{F}, out_qvals_S_A) where {F}
+    @assert size(out_qvals_S_A) == (n_states(m), n_actions(m))
+    for a in 1:n_actions(m)
+        out_qvals_S_A[:, a] = reward_S + discount(m) * transition_A_S_S2[a] * value_S
+    end
+end
+
+function transition_matrix_a_s_sp(mdp::MDP)
+    # Thanks to zach
+    na = n_actions(mdp)
+    ns = n_states(mdp)
+    transmat_row_A = [Float64[] for _ in 1:n_actions(mdp)]
+    transmat_col_A = [Float64[] for _ in 1:n_actions(mdp)]
+    transmat_data_A = [Float64[] for _ in 1:n_actions(mdp)]
+
+    for a in actions(mdp)
+        ai = actionindex(mdp, a)
+        for s in states(mdp)
+            si = stateindex(mdp, s)
+            if !isterminal(mdp, s) # if terminal, the transition probabilities are all just zero
+                td = transition(mdp, s, a)
+                for (sp, p) in weighted_iterator(td)
+                    if p > 0.0
+                        spi = stateindex(mdp, sp)
+                        push!(transmat_row_A[ai], si)
+                        push!(transmat_col_A[ai], spi)
+                        push!(transmat_data_A[ai], p)
+                    end
+                end
+            else
+                push!(transmat_row_A[ai], si)
+                push!(transmat_col_A[ai], si)
+                push!(transmat_data_A[ai], 1.0)
+            end
+        end
+    end
+    transmats_A_S_S2 = [sparse(transmat_row_A[a], transmat_col_A[a], transmat_data_A[a], n_states(mdp), n_states(mdp)) for a in 1:n_actions(mdp)]
+    @assert all(all(sum(transmats_A_S_S2[a], dims=2) .≈ ones(n_states(mdp))) for a in 1:n_actions(mdp)) "Transition probabilities must sum to 1"
+    return transmats_A_S_S2
+end
+
+function reward_s(mdp::MDP)
+    reward_S = zeros(n_states(mdp))
+    for s in states(mdp)
+        reward_S[stateindex(mdp, s)] = reward(mdp, s)
+    end
+    return reward_S
+end
+
+function solve(solver::SparseValueIterationSolver, mdp::Union{MDP, POMDP})
+    nS = n_states(mdp)
+    nA = n_actions(mdp)
+    if isempty(solver.init_util)
+        v_S = zeros(nS)
+    else
+        @assert length(solver.init_util) == nS "Input utility dimension mismatch"
+        v_S = solver.init_util
+    end
+
+    transition_A_S_S2 = transition_matrix_a_s_sp(mdp)
+    reward_S = reward_s(mdp)
+    qvals_S_A = zeros(nS, nA)
+    maxchanges_T = zeros(solver.max_iterations)
+
+    total_time = 0.0
+    for i in 1:solver.max_iterations
+        iter_time = @elapsed begin
+            qvalue!(mdp, transition_A_S_S2, reward_S, v_S, qvals_S_A)
+            new_v_S = dropdims(maximum(qvals_S_A, dims=2), dims=2)
+            @assert size(v_S) == size(new_v_S)
+            maxchanges_T[i] = maximum(abs.(new_v_S .- v_S))
+            v_S = new_v_S
+        end
+        total_time += iter_time
+        if solver.verbose
+            @info "residual: $(maxchanges_T[i]), time: $(iter_time), total time: $(total_time) " i
+        end
+        maxchanges_T[i] < solver.belres ? break : nothing
+    end
+    qvalue!(mdp, transition_A_S_S2, reward_S, v_S, qvals_S_A)
+    # Rounding to avoid floating point error noise
+    policy_S = dropdims(getindex.(argmax(round.(qvals_S_A, digits=20), dims=2), 2), dims=2)
+    policy = SparseVIPolicy(mdp, qvals_S_A, v_S, policy_S)
+end
+
+function action(policy::SparseVIPolicy, s::S) where S
+    sidx = stateindex(policy.mdp, s)
+    aidx = policy.policy_S[sidx]
+    return policy.action_map[aidx]
+end
+
+function value(policy::SparseVIPolicy, s::S) where S
+    sidx = stateindex(policy.mdp, s)
+    return policy.v_S[sidx]
+end

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -67,17 +67,12 @@ function transition_matrix_a_s_sp(mdp::MDP)
                         push!(transmat_data_A[ai], p)
                     end
                 end
-            else
-                # Terminal state
-                # Note: Assumes that reward is R(s,a) and sp is absorbing state
-                push!(transmat_row_A[ai], si)
-                push!(transmat_col_A[ai], si)
-                push!(transmat_data_A[ai], 1.0)
             end
         end
     end
     transmats_A_S_S2 = [sparse(transmat_row_A[a], transmat_col_A[a], transmat_data_A[a], n_states(mdp), n_states(mdp)) for a in 1:n_actions(mdp)]
-    @assert all(all(sum(transmats_A_S_S2[a], dims=2) .≈ ones(n_states(mdp))) for a in 1:n_actions(mdp)) "Transition probabilities must sum to 1"
+    # Note: not valid for terminal states
+    # @assert all(all(sum(transmats_A_S_S2[a], dims=2) .≈ ones(n_states(mdp))) for a in 1:n_actions(mdp)) "Transition probabilities must sum to 1"
     return transmats_A_S_S2
 end
 

--- a/src/vanilla.jl
+++ b/src/vanilla.jl
@@ -15,56 +15,6 @@ function ValueIterationSolver(;max_iterations::Int64 = 100,
     return ValueIterationSolver(max_iterations, belres, verbose, include_Q, init_util)
 end
 
-# The policy type
-mutable struct ValueIterationPolicy <: Policy
-    qmat::Matrix{Float64} # Q matrix storing Q(s,a) values
-    util::Vector{Float64} # The value function V(s)
-    policy::Vector{Int64} # Policy array, maps state index to action index
-    action_map::Vector # Maps the action index to the concrete action type
-    include_Q::Bool # Flag for including the Q-matrix
-    mdp::Union{MDP,POMDP} # uses the model for indexing in the action function
-end
-
-# constructor with an optinal initial value function argument
-function ValueIterationPolicy(mdp::Union{MDP,POMDP};
-                              utility::Vector{Float64}=zeros(n_states(mdp)),
-                              policy::Vector{Int64}=zeros(Int64, n_states(mdp)),
-                              include_Q::Bool=true)
-    ns = n_states(mdp)
-    na = n_actions(mdp)
-    @assert length(utility) == ns "Input utility dimension mismatch"
-    @assert length(policy) == ns "Input policy dimension mismatch"
-    action_map = ordered_actions(mdp)
-    include_Q ? qmat = zeros(ns,na) : qmat = zeros(0,0)
-    return ValueIterationPolicy(qmat, utility, policy, action_map, include_Q, mdp)
-end
-
-# constructor for solved q, util and policy
-function ValueIterationPolicy(mdp::Union{MDP,POMDP}, q::Matrix{Float64}, util::Vector{Float64}, policy::Vector{Int64})
-    action_map = ordered_actions(mdp)
-    include_Q = true
-    return ValueIterationPolicy(q, util, policy, action_map, include_Q, mdp)
-end
-
-# constructor for default Q-matrix
-function ValueIterationPolicy(mdp::Union{MDP,POMDP}, q::Matrix{Float64})
-    (ns, na) = size(q)
-    p = zeros(ns)
-    u = zeros(ns)
-    for i = 1:ns
-        p[i] = argmax(q[i,:])
-        u[i] = maximum(q[i,:])
-    end
-    action_map = ordered_actions(mdp)
-    include_Q = true
-    return ValueIterationPolicy(q, u, p, action_map, include_Q, mdp)
-end
-
-# returns the fields of the policy type
-function locals(p::ValueIterationPolicy)
-    return (p.qmat,p.util,p.policy,p.action_map)
-end
-
 @POMDP_require solve(solver::ValueIterationSolver, mdp::Union{MDP,POMDP}) begin
     P = typeof(mdp)
     S = statetype(P)
@@ -182,25 +132,5 @@ function solve(solver::ValueIterationSolver, mdp::Union{MDP,POMDP}; kwargs...)
         return ValueIterationPolicy(mdp, qmat, util, pol)
     else
         return ValueIterationPolicy(mdp, utility=util, policy=pol, include_Q=false)
-    end
-end
-
-function action(policy::ValueIterationPolicy, s::S) where S
-    sidx = stateindex(policy.mdp, s)
-    aidx = policy.policy[sidx]
-    return policy.action_map[aidx]
-end
-
-function value(policy::ValueIterationPolicy, s::S) where S
-    sidx = stateindex(policy.mdp, s)
-    policy.util[sidx]
-end
-
-function POMDPPolicies.actionvalues(policy::ValueIterationPolicy, s::S) where S
-    if !policy.include_Q
-        error("ValueIterationPolicyError: the policy does not contain the Q function!")
-    else
-        sidx = stateindex(policy.mdp, s)
-        return policy.qmat[sidx,:]
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,22 +1,25 @@
 using DiscreteValueIteration
 using POMDPModels
 using POMDPModelTools
-using POMDPPolicies
 using POMDPs
 using Test
 
 # Test basic value iteration functionality
 @testset "all" begin
-@testset "policy" begin
-    include("test_value_iteration_policy.jl") # test the policy object
-end
-@testset "basic" begin
-    include("test_basic_value_iteration.jl")  # then the creation of a policy
-end
-@testset "basic disallowing actions" begin
-    include("test_basic_value_iteration_disallowing_actions.jl") # then a complex form where states determine actions
-end
+    @testset "policy" begin
+        include("test_value_iteration_policy.jl") # test the policy object
+    end
+    @testset "basic" begin
+        include("test_basic_value_iteration.jl")  # then the creation of a policy
+    end
+    @testset "basic disallowing actions" begin
+        include("test_basic_value_iteration_disallowing_actions.jl") # then a complex form where states determine actions
+    end
 
-println("Testing Requirements")
-@requirements_info ValueIterationSolver() LegacyGridWorld()
+    @testset "sparse" begin
+        include("test_sparse.jl")
+    end
+
+    println("Testing Requirements")
+    @requirements_info ValueIterationSolver() LegacyGridWorld()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,50 @@ using POMDPPolicies
 using POMDPs
 using Test
 
+
+# special grid world for some tests:
+#  - reward(m, s, a, sp)
+#  - constrained actions
+mutable struct SpecialGridWorld <: MDP{GridWorldState, GridWorldAction}
+    gw::LegacyGridWorld
+end
+
+POMDPs.discount(g::SpecialGridWorld) = discount(g.gw)
+POMDPs.n_states(g::SpecialGridWorld) = n_states(g.gw)
+POMDPs.n_actions(g::SpecialGridWorld) = n_actions(g.gw)
+POMDPs.transition(g::SpecialGridWorld, s::GridWorldState, a::GridWorldAction) = transition(g.gw, s, a)
+POMDPs.reward(g::SpecialGridWorld, s::GridWorldState, a::GridWorldAction, sp::GridWorldState) = reward(g.gw, s, a, sp)
+POMDPs.stateindex(g::SpecialGridWorld, s::GridWorldState) = stateindex(g.gw, s)
+POMDPs.actionindex(g::SpecialGridWorld, a::GridWorldAction) = actionindex(g.gw, a)
+POMDPs.actions(g::SpecialGridWorld, s::GridWorldState) = actions(g.gw, s)
+POMDPs.states(g::SpecialGridWorld) = states(g.gw)
+POMDPs.actions(g::SpecialGridWorld) = actions(g.gw)
+
+SpecialGridWorld() = SpecialGridWorld(LegacyGridWorld(sx=2, sy=3, rs = [GridWorldState(2,3)], rv = [10.0]))
+
+# Let's extend actions to hard-code & limit to the
+# particular feasible actions from each state....
+function POMDPs.actions(mdp::SpecialGridWorld, s::GridWorldState)
+    # up: 1, down: 2, left: 3, right: 4
+    sidx = stateindex(mdp, s)
+    if sidx == 1
+        acts = [GridWorldAction(:left), GridWorldAction(:right)]
+    elseif sidx == 2
+        acts = [GridWorldAction(:up), GridWorldAction(:right)]
+    elseif sidx == 3
+        acts = [GridWorldAction(:left), GridWorldAction(:up)]
+    elseif sidx == 4
+        acts = [GridWorldAction(:left), GridWorldAction(:right)]
+    elseif sidx == 5
+        acts = [GridWorldAction(:left), GridWorldAction(:right)]
+    elseif sidx == 6
+        acts = [GridWorldAction(:up), GridWorldAction(:down), GridWorldAction(:left), GridWorldAction(:right)]
+    elseif sidx == 7
+        acts = [GridWorldAction(:up), GridWorldAction(:down), GridWorldAction(:left), GridWorldAction(:right)]
+    end
+    return acts
+end
+
 # Test basic value iteration functionality
 @testset "all" begin
     @testset "policy" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using DiscreteValueIteration
 using POMDPModels
 using POMDPModelTools
+using POMDPPolicies
 using POMDPs
 using Test
 

--- a/test/test_basic_value_iteration_disallowing_actions.jl
+++ b/test/test_basic_value_iteration_disallowing_actions.jl
@@ -1,42 +1,3 @@
-mutable struct SpecialGridWorld <: MDP{GridWorldState, GridWorldAction}
-    gw::LegacyGridWorld
-end
-
-POMDPs.discount(g::SpecialGridWorld) = discount(g.gw)
-POMDPs.n_states(g::SpecialGridWorld) = n_states(g.gw)
-POMDPs.n_actions(g::SpecialGridWorld) = n_actions(g.gw)
-POMDPs.transition(g::SpecialGridWorld, s::GridWorldState, a::GridWorldAction) = transition(g.gw, s, a)
-POMDPs.reward(g::SpecialGridWorld, s::GridWorldState, a::GridWorldAction, sp::GridWorldState) = reward(g.gw, s, a, sp)
-POMDPs.stateindex(g::SpecialGridWorld, s::GridWorldState) = stateindex(g.gw, s)
-POMDPs.actionindex(g::SpecialGridWorld, a::GridWorldAction) = actionindex(g.gw, a)
-POMDPs.actions(g::SpecialGridWorld, s::GridWorldState) = actions(g.gw, s)
-POMDPs.states(g::SpecialGridWorld) = states(g.gw)
-POMDPs.actions(g::SpecialGridWorld) = actions(g.gw)
-
-# Let's extend actions to hard-code & limit to the
-# particular feasible actions from each state....
-function POMDPs.actions(mdp::SpecialGridWorld, s::GridWorldState)
-    # up: 1, down: 2, left: 3, right: 4
-    sidx = stateindex(mdp, s)
-    if sidx == 1
-        acts = [GridWorldAction(:left), GridWorldAction(:right)]
-    elseif sidx == 2
-        acts = [GridWorldAction(:up), GridWorldAction(:right)]
-    elseif sidx == 3
-        acts = [GridWorldAction(:left), GridWorldAction(:up)]
-    elseif sidx == 4
-        acts = [GridWorldAction(:left), GridWorldAction(:right)]
-    elseif sidx == 5
-        acts = [GridWorldAction(:left), GridWorldAction(:right)]
-    elseif sidx == 6
-        acts = [GridWorldAction(:up), GridWorldAction(:down), GridWorldAction(:left), GridWorldAction(:right)]
-    elseif sidx == 7
-        acts = [GridWorldAction(:up), GridWorldAction(:down), GridWorldAction(:left), GridWorldAction(:right)]
-    end
-    return acts
-end
-
-
 function test_conditioning_actions_on_state()
     # Condition available actions on next state....
     # GridWorld(sx=2,sy=3) w reward at (2,3):
@@ -63,5 +24,3 @@ function test_conditioning_actions_on_state()
 end
 
 @test test_conditioning_actions_on_state() == true
-
-println("Finished tests")

--- a/test/test_sparse.jl
+++ b/test/test_sparse.jl
@@ -5,7 +5,13 @@ function test_sparse_vanilla_same(m)
     sparse_policy = solve(sparse_solver, m)
     @test vanilla_policy.policy == sparse_policy.policy
     @test isapprox(vanilla_policy.util, sparse_policy.util; atol=1e-3)
-    @test isapprox(vanilla_policy.qmat, sparse_policy.qmat; atol=1e-3)
+    for s in states(m)
+        si = stateindex(m, s)
+        for a in actions(m, s)
+            ai = actionindex(m, a)
+            @test isapprox(vanilla_policy.qmat[si, ai], sparse_policy.qmat[si, ai]; atol=1e-3)
+        end
+    end
 end
 
 m1 = SimpleGridWorld(size=(10,10))

--- a/test/test_sparse.jl
+++ b/test/test_sparse.jl
@@ -4,9 +4,9 @@ function test_sparse_vanilla_same()
     sparse_solver = SparseValueIterationSolver(max_iterations=500, belres=1e-8)
     vanilla_policy = solve(vanilla_solver, gridworld)
     sparse_policy = solve(sparse_solver, gridworld)
-    @test vanilla_policy.policy == sparse_policy.policy_S
-    @test isapprox(vanilla_policy.util, sparse_policy.v_S; atol=1e-3)
-    @test isapprox(vanilla_policy.qmat, sparse_policy.qvals_S_A; atol=1e-3)
+    @test vanilla_policy.policy == sparse_policy.policy
+    @test isapprox(vanilla_policy.util, sparse_policy.util; atol=1e-3)
+    @test isapprox(vanilla_policy.qmat, sparse_policy.qmat; atol=1e-3)
 end
 
 test_sparse_vanilla_same()

--- a/test/test_sparse.jl
+++ b/test/test_sparse.jl
@@ -1,0 +1,12 @@
+function test_sparse_vanilla_same()
+    gridworld = SimpleGridWorld(size=(10,10))
+    vanilla_solver = ValueIterationSolver(max_iterations=500, belres=1e-8)
+    sparse_solver = SparseValueIterationSolver(max_iterations=500, belres=1e-8)
+    vanilla_policy = solve(vanilla_solver, gridworld)
+    sparse_policy = solve(sparse_solver, gridworld)
+    @test vanilla_policy.policy == sparse_policy.policy_S
+    @test isapprox(vanilla_policy.util, sparse_policy.v_S; atol=1e-3)
+    @test isapprox(vanilla_policy.qmat, sparse_policy.qvals_S_A; atol=1e-3)
+end
+
+test_sparse_vanilla_same()

--- a/test/test_sparse.jl
+++ b/test/test_sparse.jl
@@ -1,12 +1,15 @@
-function test_sparse_vanilla_same()
-    gridworld = SimpleGridWorld(size=(10,10))
+function test_sparse_vanilla_same(m)
     vanilla_solver = ValueIterationSolver(max_iterations=500, belres=1e-8)
     sparse_solver = SparseValueIterationSolver(max_iterations=500, belres=1e-8)
-    vanilla_policy = solve(vanilla_solver, gridworld)
-    sparse_policy = solve(sparse_solver, gridworld)
+    vanilla_policy = solve(vanilla_solver, m)
+    sparse_policy = solve(sparse_solver, m)
     @test vanilla_policy.policy == sparse_policy.policy
     @test isapprox(vanilla_policy.util, sparse_policy.util; atol=1e-3)
     @test isapprox(vanilla_policy.qmat, sparse_policy.qmat; atol=1e-3)
 end
 
-test_sparse_vanilla_same()
+m1 = SimpleGridWorld(size=(10,10))
+test_sparse_vanilla_same(m1)
+
+m2 = SpecialGridWorld()
+test_sparse_vanilla_same(m2)


### PR DESCRIPTION
Never mind.

Special thanks to @zsunberg for reminding me about `weighted_iterator`

Fixes #21 

Benchmarking:

```
size = (10, 10)
[ Info: Sparse
  5.721 ms (48672 allocations: 20.10 MiB)
[ Info: Vanilla
  367.689 ms (8177250 allocations: 357.01 MiB)
size = (100, 100)
[ Info: Sparse
  566.239 ms (2456885 allocations: 1.84 GiB)
[ Info: Vanilla
  39.364 s (935603138 allocations: 37.78 GiB)
```