### PR TITLE
Terminal states handling in Sparse VI

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.7
 POMDPs
-POMDPModelTools
+POMDPModelTools 0.1.3
 POMDPPolicies
 SparseArrays

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -79,15 +79,19 @@ end
 function reward_s_a(mdp::MDP)
     reward_S_A = fill(-Inf, (n_states(mdp), n_actions(mdp))) # set reward for all actions to -Inf unless they are in actions(mdp, s)
     for s in states(mdp)
-        for a in actions(mdp, s)
-            td = transition(mdp, s, a)
-            r = 0.0
-            for (sp, p) in weighted_iterator(td)
-                if p > 0.0
-                    r += p*reward(mdp, s, a, sp)
+        if isterminal(mdp, s)
+            reward_S_A[stateindex(mdp, s), :] .= 0.0
+        else
+            for a in actions(mdp, s)
+                td = transition(mdp, s, a)
+                r = 0.0
+                for (sp, p) in weighted_iterator(td)
+                    if p > 0.0
+                        r += p*reward(mdp, s, a, sp)
+                    end
                 end
+                reward_S_A[stateindex(mdp, s), actionindex(mdp, a)] = r
             end
-            reward_S_A[stateindex(mdp, s), actionindex(mdp, a)] = r
         end
     end
     return reward_S_A

--- a/test/test_sparse.jl
+++ b/test/test_sparse.jl
@@ -19,3 +19,30 @@ test_sparse_vanilla_same(m1)
 
 m2 = SpecialGridWorld()
 test_sparse_vanilla_same(m2)
+
+## Two state MDP to test for terminal states
+
+struct TwoStatesMDP <: MDP{Int, Int} end
+
+POMDPs.n_states(mdp::TwoStatesMDP) = 2
+POMDPs.states(mdp::TwoStatesMDP) = 1:2
+POMDPs.stateindex(mdp::TwoStatesMDP, s) = s 
+POMDPs.n_actions(mdp::TwoStatesMDP) = 2
+POMDPs.actions(mdp::TwoStatesMDP) = 1:2
+POMDPs.actionindex(mdp::TwoStatesMDP, a) = a
+POMDPs.discount(mdp::TwoStatesMDP) = 0.95
+POMDPs.transition(mdp::TwoStatesMDP, s, a) = SparseCat([a], [1.0])
+POMDPs.reward(mdp::TwoStatesMDP, s, a, sp) = float(sp == 2)
+POMDPs.isterminal(mdp::TwoStatesMDP, s) = s == 2
+
+
+mdp = TwoStatesMDP()
+solver = ValueIterationSolver(verbose = true)
+policy = solve(solver, mdp)
+
+sparsesolver = SparseValueIterationSolver(verbose=true)
+sparsepolicy = solve(sparsesolver, mdp)
+
+@test sparsepolicy.qmat == policy.qmat 
+@test value(sparsepolicy, 2) ≈ 0.0
+


### PR DESCRIPTION
When building the R(s, a) matrix from R(s, a, sp) it ensures that R(s, a) is zero for the terminal states. 

fixes #27 and also #26 

Here is a MWE for #26: 
```julia 
using POMDPs
using DiscreteValueIteration
using SubHunt
using POMDPModelTools

mdp = UnderlyingMDP(SubHuntPOMDP())

policy = solve(ValueIterationSolver(), mdp)
```