### PR TITLE
change argument's type of two functions from "MDP" to "Union{MDP,POMDP}"

### DIFF
--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -45,7 +45,7 @@ function qvalue!(m::Union{MDP,POMDP}, transition_A_S_S2, reward_S_A::AbstractMat
     end
 end
 
-function transition_matrix_a_s_sp(mdp::MDP)
+function transition_matrix_a_s_sp(mdp::Union{MDP,POMDP})
     # Thanks to zach
     na = n_actions(mdp)
     ns = n_states(mdp)
@@ -76,7 +76,7 @@ function transition_matrix_a_s_sp(mdp::MDP)
     return transmats_A_S_S2
 end
 
-function reward_s_a(mdp::MDP)
+function reward_s_a(mdp::Union{MDP,POMDP})
     reward_S_A = fill(-Inf, (n_states(mdp), n_actions(mdp))) # set reward for all actions to -Inf unless they are in actions(mdp, s)
     for s in states(mdp)
         if isterminal(mdp, s)


### PR DESCRIPTION
When I check the source code of [QMDP](https://github.com/JuliaPOMDP/QMDP.jl) solver, which is a POMDP solver, I find that _ValueIterationSolver_ from this repo is used. And in this repo, a faster solver _SparseValueIterationSolver_ is also provided. So I think maybe I can modify the source code of QMDP to add this solver as an optional solver. But soon I find that the two functions transition_matrix_a_s_sp(mdp::MDP) and reward_s_a(mdp::MDP) only accept argument of MDP Type. According to my understanding this two function can actually also accept POMDP type. I have tried the modified version in my QMDP solver and everything runs smoothly.  The results are also as expected.