### PR TITLE
Made printing of policies in REPL and notebook nicer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,9 @@ POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
+[compat]
+POMDPPolicies = ">= 0.1.4"
+
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"

--- a/src/common.jl
+++ b/src/common.jl
@@ -67,3 +67,11 @@ function POMDPPolicies.actionvalues(policy::ValueIterationPolicy, s::S) where S
         return policy.qmat[sidx,:]
     end
 end
+
+function Base.show(io::IO, mime::MIME"text/plain", p::ValueIterationPolicy)
+    summary(io, p)
+    println(io, ':')
+    ds = get(io, :displaysize, displaysize(io))
+    ioc = IOContext(io, :displaysize=>(first(ds)-1, last(ds)))
+    showpolicy(ioc, mime, p.mdp, p)
+end

--- a/test/test_value_iteration_policy.jl
+++ b/test/test_value_iteration_policy.jl
@@ -79,3 +79,13 @@ end
 @test test_creation_of_policy_given_policy() == true
 @test test_actionvalues()
 @test_throws ErrorException test_actionvalues_error()
+
+@testset "policy show" begin
+    mdp = LegacyGridWorld(sx=1, sy=3, rs = [GridWorldState(1,3)], rv = [10.0])
+    correct_qmat = [5.45636 5.1835 5.1835 5.1835; 8.20506 6.47848 7.7948 7.7948; 10.0 10.0 10.0 10.0; 0.0 0.0 0.0 0.0]
+    policy = ValueIterationPolicy(mdp, correct_qmat)
+    iob = IOBuffer()
+    io = IOContext(iob, :limit=>true, :displaysize=>(10, 80))
+    show(io, MIME("text/plain"), policy)
+    @test String(take!(iob)) == "ValueIterationPolicy{Float64}:\n GridWorldState(1, 1, false) -> :up\n GridWorldState(1, 2, false) -> :up\n GridWorldState(1, 3, false) -> :up\n GridWorldState(0, 0, true) -> :up"
+end


### PR DESCRIPTION
Now printing looks like this in the REPL and notebooks

![Screenshot from 2019-06-01 08-22-14](https://user-images.githubusercontent.com/4240491/58750469-beca8a80-8447-11e9-8533-74be0258aefc.png)

Does this seem good?