### PR TITLE
Sparse VI optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ repo = "https://github.com/JuliaPOMDP/DiscreteValueIteration.jl.git"
 version = "0.4.6"
 
 [deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 POMDPLinter = "f3bd98c0-eb40-45e2-9eb1-f2763262d755"
 POMDPTools = "7588e00f-9cae-40de-98dc-e0c70c48cdd7"
 POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
@@ -15,11 +16,3 @@ POMDPLinter = "0.1"
 POMDPTools = "0.1"
 POMDPs = "0.8, 0.9"
 julia = "1"
-
-[extras]
-DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test", "POMDPModels", "DelimitedFiles"]

--- a/src/DiscreteValueIteration.jl
+++ b/src/DiscreteValueIteration.jl
@@ -7,9 +7,10 @@ using Printf
 using POMDPs
 using POMDPTools
 using SparseArrays
+using LinearAlgebra
 import POMDPLinter: @POMDP_require, @req, @subreq, @warn_requirements
 
-import POMDPs: Solver, solve, Policy, action, value 
+import POMDPs: Solver, solve, Policy, action, value
 
 export
     ValueIterationPolicy,

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -57,7 +57,7 @@ end
 
 function _value!(V, q_vals_S_A)
     δ_max = 0.0
-    for i ∈ 1:size(q_vals_S_A,2)
+    for i ∈ 1:size(q_vals_S_A, 1)
         vp = maximum(@view q_vals_S_A[i,:])
         δ = abs(V[i] - vp)
         δ > δ_max && (δ_max = δ)

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -46,6 +46,26 @@ function qvalue!(m::Union{MDP,POMDP}, transition_A_S_S2, reward_S_A::AbstractMat
     end
 end
 
+function qvalue!(m::MDP, transition_A_S_S2, reward_S_A, value_S, out_qvals_S_A, _mul_cache)
+    @assert size(out_qvals_S_A) == (length(states(m)), length(actions(m)))
+    γ = discount(m)
+    for a in 1:length(actions(m))
+        Vp = mul!(_mul_cache, transition_A_S_S2[a], value_S)
+        out_qvals_S_A[:, a] .= view(reward_S_A, :, a) .+ γ .* Vp
+    end
+end
+
+function _value!(V, q_vals_S_A)
+    δ_max = 0.0
+    for i ∈ 1:size(q_vals_S_A,2)
+        vp = maximum(@view q_vals_S_A[i,:])
+        δ = abs(V[i] - vp)
+        δ > δ_max && (δ_max = δ)
+        V[i] = vp
+    end
+    return δ_max
+end
+
 function solve(solver::SparseValueIterationSolver, mdp::SparseTabularMDP)
     nS = length(states(mdp))
     nA = length(actions(mdp))
@@ -55,6 +75,7 @@ function solve(solver::SparseValueIterationSolver, mdp::SparseTabularMDP)
         @assert length(solver.init_util) == nS "Input utility dimension mismatch"
         v_S = solver.init_util
     end
+    _mul_cache = similar(v_S)
 
     transition_A_S_S2 = transition_matrices(mdp)
     reward_S_A = reward_matrix(mdp)
@@ -64,27 +85,24 @@ function solve(solver::SparseValueIterationSolver, mdp::SparseTabularMDP)
     total_time = 0.0
     for i in 1:solver.max_iterations
         iter_time = @elapsed begin
-            qvalue!(mdp, transition_A_S_S2, reward_S_A, v_S, qvals_S_A)
-            new_v_S = dropdims(maximum(qvals_S_A, dims=2), dims=2)
-            @assert size(v_S) == size(new_v_S)
-            maxchanges_T[i] = maximum(abs.(new_v_S .- v_S))
-            v_S = new_v_S
+            qvalue!(mdp, transition_A_S_S2, reward_S_A, v_S, qvals_S_A, _mul_cache)
+            maxchanges_T[i] = _value!(v_S, qvals_S_A)
         end
         total_time += iter_time
         if solver.verbose
             @info "residual: $(maxchanges_T[i]), time: $(iter_time), total time: $(total_time) " i
         end
-        maxchanges_T[i] < solver.belres ? break : nothing
+        maxchanges_T[i] < solver.belres && break
     end
     qvalue!(mdp, transition_A_S_S2, reward_S_A, v_S, qvals_S_A)
     # Rounding to avoid floating point error noise
     policy_S = dropdims(getindex.(argmax(round.(qvals_S_A, digits=20), dims=2), 2), dims=2)
-    if solver.include_Q
-        policy = ValueIterationPolicy(mdp, qvals_S_A, v_S, policy_S)
+
+    return if solver.include_Q
+        ValueIterationPolicy(mdp, qvals_S_A, v_S, policy_S)
     else
-        policy = ValueIterationPolicy(mdp, utility=v_S, policy=policy_S, include_Q=false)
+        ValueIterationPolicy(mdp, utility=v_S, policy=policy_S, include_Q=false)
     end
-    return policy
 end
 
 function solve(solver::SparseValueIterationSolver, mdp::MDP)

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -80,23 +80,21 @@ function solve(solver::SparseValueIterationSolver, mdp::SparseTabularMDP)
     transition_A_S_S2 = transition_matrices(mdp)
     reward_S_A = reward_matrix(mdp)
     qvals_S_A = zeros(nS, nA)
-    maxchanges_T = zeros(solver.max_iterations)
 
     total_time = 0.0
     for i in 1:solver.max_iterations
         iter_time = @elapsed begin
             qvalue!(mdp, transition_A_S_S2, reward_S_A, v_S, qvals_S_A, _mul_cache)
-            maxchanges_T[i] = _value!(v_S, qvals_S_A)
+            δ = _value!(v_S, qvals_S_A)
         end
         total_time += iter_time
         if solver.verbose
-            @info "residual: $(maxchanges_T[i]), time: $(iter_time), total time: $(total_time) " i
+            @info "residual: $(δ), time: $(iter_time), total time: $(total_time) " i
         end
-        maxchanges_T[i] < solver.belres && break
+        δ < solver.belres && break
     end
-    qvalue!(mdp, transition_A_S_S2, reward_S_A, v_S, qvals_S_A)
-    # Rounding to avoid floating point error noise
-    policy_S = dropdims(getindex.(argmax(round.(qvals_S_A, digits=20), dims=2), 2), dims=2)
+    qvalue!(mdp, transition_A_S_S2, reward_S_A, v_S, qvals_S_A, _mul_cache)
+    policy_S = argmax.(eachrow(qvals_S_A))
 
     return if solver.include_Q
         ValueIterationPolicy(mdp, qvals_S_A, v_S, policy_S)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+POMDPLinter = "f3bd98c0-eb40-45e2-9eb1-f2763262d755"
+POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
+POMDPTools = "7588e00f-9cae-40de-98dc-e0c70c48cdd7"
+POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ POMDPs.actionindex(g::SpecialGridWorld, a::GridWorldAction) = actionindex(g.gw, 
 POMDPs.actions(g::SpecialGridWorld, s::GridWorldState) = actions(g.gw, s)
 POMDPs.states(g::SpecialGridWorld) = states(g.gw)
 POMDPs.actions(g::SpecialGridWorld) = actions(g.gw)
+POMDPs.initialstate(g::SpecialGridWorld) = Uniform(states(g))
 
 SpecialGridWorld() = SpecialGridWorld(LegacyGridWorld(sx=2, sy=3, rs = [GridWorldState(2,3)], rv = [10.0]))
 

--- a/test/test_basic_value_iteration.jl
+++ b/test/test_basic_value_iteration.jl
@@ -43,20 +43,20 @@ function test_simple_grid()
     # ----------------------------------------------
     # 7 (0,0) is absorbing state
     mdp = LegacyGridWorld(sx=2, sy=3, rs = [GridWorldState(2,3)], rv = [10.0])
-    
+
     solver = ValueIterationSolver(verbose=true)
     policy = solve(solver, mdp)
 
     # up: 1, down: 2, left: 3, right: 4
     correct_policy = [1,1,1,1,4,1,1] # alternative policies
-    # are possible, but since they are tied & the first 
+    # are possible, but since they are tied & the first
     # action is always 1, we will always return 1 for tied
     # actions
     return policy.policy == correct_policy
 end
 
 function test_init_solution()
-    # Initialize the value to the solution 
+    # Initialize the value to the solution
     rstates = [GridWorldState(4,3), GridWorldState(4,6), GridWorldState(9,3), GridWorldState(8,8)]
     rvals = [-10.0, -5.0, 10.0, 3.0]
     xs = 10
@@ -88,7 +88,7 @@ end
 function test_warning()
     mdp = LegacyGridWorld()
     solver = ValueIterationSolver()
-    println("There should be a warning bellow: ")
+    println("There should be a warning below: ")
     solve(solver, mdp, verbose=true)
 end
 

--- a/test/test_sparse.jl
+++ b/test/test_sparse.jl
@@ -25,13 +25,14 @@ test_sparse_vanilla_same(m2)
 struct TwoStatesMDP <: MDP{Int, Int} end
 
 POMDPs.states(mdp::TwoStatesMDP) = 1:2
-POMDPs.stateindex(mdp::TwoStatesMDP, s) = s 
+POMDPs.stateindex(mdp::TwoStatesMDP, s) = s
 POMDPs.actions(mdp::TwoStatesMDP) = 1:2
 POMDPs.actionindex(mdp::TwoStatesMDP, a) = a
 POMDPs.discount(mdp::TwoStatesMDP) = 0.95
 POMDPs.transition(mdp::TwoStatesMDP, s, a) = SparseCat([a], [1.0])
 POMDPs.reward(mdp::TwoStatesMDP, s, a, sp) = float(sp == 2)
 POMDPs.isterminal(mdp::TwoStatesMDP, s) = s == 2
+POMDPs.initialstate(mdp::TwoStatesMDP) = Uniform(states(mdp))
 
 
 mdp = TwoStatesMDP()
@@ -41,7 +42,7 @@ policy = solve(solver, mdp)
 sparsesolver = SparseValueIterationSolver(verbose=true)
 sparsepolicy = solve(sparsesolver, mdp)
 
-@test sparsepolicy.qmat == policy.qmat 
+@test sparsepolicy.qmat == policy.qmat
 @test value(sparsepolicy, 2) ≈ 0.0
 @test_throws String solve(SparseValueIterationSolver(), TigerPOMDP())
 


### PR DESCRIPTION
Sparse VI implementation on master has some crazy intermediary allocations

-----
# Benchmarks

```julia
mdp = SparseTabularMDP(SimpleGridWorld(size=(100,100)))
sol = SparseValueIterationSolver(max_iterations=1_000, belres=0.0)
@benchmark solve(sol, mdp)
```

## Master
```julia
BenchmarkTools.Trial: 16 samples with 1 evaluation.
 Range (min … max):  310.832 ms … 344.604 ms  ┊ GC (min … max): 5.08% … 11.91%
 Time  (median):     328.850 ms               ┊ GC (median):    8.23%
 Time  (mean ± σ):   326.575 ms ±   9.168 ms  ┊ GC (mean ± σ):  8.31% ±  1.79%

  █          ▁ ▁   ▁   ▁         █ ▁▁▁▁▁    ▁  ▁              ▁  
  █▁▁▁▁▁▁▁▁▁▁█▁█▁▁▁█▁▁▁█▁▁▁▁▁▁▁▁▁█▁█████▁▁▁▁█▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  311 ms           Histogram: frequency by time          345 ms <

 Memory estimate: 1.05 GiB, allocs estimate: 41056.
```

## This PR
```julia
BenchmarkTools.Trial: 28 samples with 1 evaluation.
 Range (min … max):  181.719 ms … 186.178 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     183.634 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   183.658 ms ± 822.542 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

                   ▄    █    ▁      ▁█                           
  ▆▁▁▁▁▁▆▁▁▁▁▁▁▁▆▁▁█▁▁▆▁█▆▆▆▆█▁▆▁▆▆▁██▁▆▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆ ▁
  182 ms           Histogram: frequency by time          186 ms <

 Memory estimate: 938.73 KiB, allocs estimate: 22.
```
